### PR TITLE
fix(sensor): resolve unawaited coroutine and duplicate entity ID errors

### DIFF
--- a/custom_components/spoolman/sensor.py
+++ b/custom_components/spoolman/sensor.py
@@ -4,7 +4,7 @@ import logging
 import os
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from PIL import Image, ImageDraw
 
@@ -60,7 +60,8 @@ async def async_setup_entry(  # noqa: C901
     # Track existing extra field entities to detect new ones
     existing_extra_fields = {}  # key: (spool_id, field_key), value: entity
 
-    async def async_add_extra_field_entities():
+    @callback
+    def add_extra_field_entities():
         """Add new extra field entities when they appear in coordinator data."""
         if not coordinator.data:
             return
@@ -88,9 +89,6 @@ async def async_setup_entry(  # noqa: C901
 
         if new_entities:
             async_add_entities(new_entities)
-
-    # Register listener for coordinator updates to add new extra fields
-    coordinator.async_add_listener(async_add_extra_field_entities)
 
     if coordinator.data:
         all_entities = []
@@ -313,6 +311,9 @@ async def async_setup_entry(  # noqa: C901
             all_entities.append(filament_device)
 
         async_add_entities(all_entities)
+
+    # Register listener for coordinator updates to add new extra fields
+    coordinator.async_add_listener(add_extra_field_entities)
 
 
 def _generate_entity_picture(spool_data, image_dir):


### PR DESCRIPTION
## 🎯 Description

I was getting this in my logs:

```
2026-02-16 14:24:11.745 WARNING (MainThread) [py.warnings] /usr/src/homeassistant/homeassistant/helpers/update_coordinator.py:200: RuntimeWarning: coroutine 'async_setup_entry.<locals>.async_add_extra_field_entities' was never awaited
```

This PR addresses two issues in the Spoolman sensor platform setup:

1.  **Fixes RuntimeWarning**: The `async_add_extra_field_entities` function was defined as [async], but passed to `coordinator.async_add_listener`, which does not await its callbacks. This caused a `RuntimeWarning: coroutine ... was never awaited`. The function has been converted to a synchronous function decorated with `@callback`. This change generated duplicate entity IDs.


2.  **Fixes Duplicate Entity IDs**: Previously, the update listener was registered *before* the initial entity creation loop finished. This created a race condition where the listener could fire and attempt to create "extra field" entities that were already being created by the main setup loop, resulting in `Platform spoolman does not generate unique IDs` errors. The listener registration has been moved to the end of [async_setup_entry] to ensure `existing_extra_fields` is fully populated first.

## 🎨 Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Configuration change
- [ ] 🎨 UI/UX improvement

## 🧪 Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this code locally
- [ ] I have added/updated unit tests that prove my fix/feature works
- [x] All existing tests pass locally
- [x] I have tested this in Home Assistant

## ✅ Checklist

<!-- Put an `x` in all boxes that apply -->

- [x] 📖 My code follows the project's coding style
- [x] 🔍 I have performed a self-review of my code
- [x] 💬 I have commented my code, particularly in hard-to-understand areas
- [x] 📚 I have updated the documentation (README, CONTRIBUTING, etc.) if needed
- [x] ⚠️ My changes generate no new warnings or errors
- [ ] 🧪 I have added tests that prove my fix is effective or that my feature works
- [x] ✅ New and existing unit tests pass locally with my changes
- [x] 🌿 I am merging into the `dev` branch (not `main`)
- [x] 📝 My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
- [x] 🔄 I have updated the integration version in `manifest.json` if needed
- [x] 🌍 I have updated translations if I changed user-facing strings

## For Maintainers

<!-- This section is for maintainers to fill out during review -->

### Review Checklist
- [ ] Code quality is acceptable
- [ ] Tests are adequate
- [ ] Documentation is updated
- [ ] Breaking changes are documented
- [ ] Ready to merge to `dev`

### Post-Merge Tasks
- [ ] Update CHANGELOG if needed
- [ ] Tag for release (if applicable)
- [ ] Update documentation site (if applicable)
