### PR TITLE
docs: add related Spoolman ecosystem projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,20 @@ actions:
 **Show it off!** Your extra field sensors work just like any other sensor - use them in cards, automations, or anywhere else!
 
 
+
+---
+
+## 🔗 Related Spoolman Projects
+
+Check out these other projects from the Spoolman ecosystem:
+
+| Project | Description |
+|---------|-------------|
+| [🧵 Spoolman MCP](https://github.com/Disane87/spoolman-mcp) | MCP Server for Spoolman — manage your filament inventory through AI assistants like Claude. Available on [npm](https://www.npmjs.com/package/@disane-dev/spoolman-mcp). |
+| [🎨 Spoolman Filament Swatch](https://github.com/Disane87/spoolman-filament-swatch) | Beautiful, interactive filament color browser for Spoolman. [Live Demo](https://spoolswatch.disane.dev/) |
+| [📦 Spoolman Filament Extractor](https://github.com/Disane87/Spoolman-filament-extractor) | Extract your filaments from Spoolman to SpoolmanDB format |
+| [🗄️ SpoolmanDB](https://github.com/Donkie/SpoolmanDB) | Centralized community filament database used by Spoolman |
+
 # 🤝 Contributing
 
 Hey there! Want to help make this integration even better? That's awesome! 🎉

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "automerge": true,
   "automergeType": "pr",
-  "baseBranches": [
+  "baseBranchPatterns": [
     "dev"
   ],
   "labels": [


### PR DESCRIPTION
Adds a Related Spoolman Projects section to cross-link with other ecosystem repos (MCP server, Filament Swatch, Filament Extractor, SpoolmanDB).