### PR TITLE
feat(sensors): expose Spoolman extra-field metadata on HA sensors

### DIFF
--- a/custom_components/spoolman/classes/spoolman_api.py
+++ b/custom_components/spoolman/classes/spoolman_api.py
@@ -59,6 +59,31 @@ class SpoolmanAPI:
             _LOGGER.debug("SpoolmanAPI: backup response %s", response)
             return response
 
+    async def get_extra_fields(self, entity_type):
+        """Return extra-field metadata for the given entity type (e.g. ``spool``).
+
+        Returns a dict keyed by field key with ``name``, ``field_type``, ``unit``,
+        ``choices`` and ``multi_choice`` so the integration can set proper HA
+        device classes / units / state classes on dynamic extra-field sensors.
+        """
+        _LOGGER.debug("SpoolmanAPI: get_extra_fields(%s)", entity_type)
+        url = f"{self.base_url}/field/{entity_type}"
+        session = await self._get_session()
+        async with session.get(url) as response:
+            response.raise_for_status()
+            payload = await response.json()
+            _LOGGER.debug("SpoolmanAPI: get_extra_fields response %s", payload)
+            return {
+                item["key"]: {
+                    "name": item.get("name"),
+                    "field_type": item.get("field_type"),
+                    "unit": item.get("unit"),
+                    "choices": item.get("choices"),
+                    "multi_choice": item.get("multi_choice"),
+                }
+                for item in payload
+            }
+
     async def get_spools(self, params):
         """Return a list of all spools."""
         _LOGGER.debug("SpoolmanAPI: get_spools")

--- a/custom_components/spoolman/coordinator.py
+++ b/custom_components/spoolman/coordinator.py
@@ -58,6 +58,12 @@ class SpoolManCoordinator(DataUpdateCoordinator):
                 {"allow_archived": show_archived}
             )
             filaments = await self.spoolman_api.get_filaments({})
+            try:
+                spool_extra_fields = await self.spoolman_api.get_extra_fields("spool")
+            except Exception as exception:
+                # Older Spoolman versions or transient errors: degrade gracefully.
+                _LOGGER.debug("Could not fetch spool extra-field metadata: %s", exception)
+                spool_extra_fields = {}
         except asyncio.CancelledError:
             # Task was cancelled (e.g., during shutdown), re-raise to let coordinator handle it
             _LOGGER.debug("Data update was cancelled")
@@ -97,7 +103,11 @@ class SpoolManCoordinator(DataUpdateCoordinator):
             _LOGGER.error(f"Error processing Klipper API data: {exception}")
             # Continue returning spools even if Klipper processing fails
 
-        return {"spools": spools, "filaments": filaments}
+        return {
+            "spools": spools,
+            "filaments": filaments,
+            "extra_fields": {"spool": spool_extra_fields},
+        }
 
     async def async_cleanup_extra_fields(self):
         """Cleanup orphaned extra field entities - can be called externally."""

--- a/custom_components/spoolman/sensors/spool_extra_field.py
+++ b/custom_components/spoolman/sensors/spool_extra_field.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import generate_entity_id
@@ -14,6 +18,33 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from ..const import CONF_URL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+_NUMERIC_FIELD_TYPES = {"integer", "float"}
+
+# Map normalized Spoolman unit strings to (device_class, icon).
+# Matched on the unit reported by Spoolman, not on the user-chosen field name,
+# so it works regardless of locale.
+_UNIT_DEVICE_CLASS = {
+    "%": (SensorDeviceClass.HUMIDITY, "mdi:water-percent"),
+    "°c": (SensorDeviceClass.TEMPERATURE, "mdi:thermometer"),
+    "°f": (SensorDeviceClass.TEMPERATURE, "mdi:thermometer"),
+    "k": (SensorDeviceClass.TEMPERATURE, "mdi:thermometer"),
+    "g": (SensorDeviceClass.WEIGHT, "mdi:weight-gram"),
+    "kg": (SensorDeviceClass.WEIGHT, "mdi:weight-kilogram"),
+    "mm": (SensorDeviceClass.DISTANCE, "mdi:ruler"),
+    "m": (SensorDeviceClass.DISTANCE, "mdi:ruler"),
+}
+
+
+def _device_class_for(field_type: str | None, unit: str | None) -> tuple[Any, str]:
+    """Pick a device class + icon based on Spoolman field metadata."""
+    if field_type == "datetime":
+        return SensorDeviceClass.TIMESTAMP, "mdi:calendar"
+    if unit:
+        match = _UNIT_DEVICE_CLASS.get(unit.strip().lower())
+        if match:
+            return match
+    return None, "mdi:tag-outline"
 
 
 class SpoolExtraField(CoordinatorEntity, SensorEntity):
@@ -42,6 +73,19 @@ class SpoolExtraField(CoordinatorEntity, SensorEntity):
         else:
             spool_name = f"Spoolman Spool {self._spool['id']}"
 
+        # Pull metadata reported by Spoolman (`/api/v1/field/spool`) so we can
+        # set proper device class / unit / state class. Falls back to a derived
+        # display name and a plain icon when metadata isn't available.
+        field_meta = (
+            (coordinator.data or {})
+            .get("extra_fields", {})
+            .get("spool", {})
+            .get(field_key, {})
+        )
+        display_name = field_meta.get("name") or field_key.replace("_", " ").title()
+        field_type = field_meta.get("field_type")
+        unit = field_meta.get("unit")
+
         # Create entity ID with the field key
         # e.g., sensor.spoolman_spool_1_extra_humidity
         safe_field_key = field_key.lower().replace(" ", "_").replace("-", "_")
@@ -52,8 +96,19 @@ class SpoolExtraField(CoordinatorEntity, SensorEntity):
         )
         self._attr_unique_id = f"spoolman_{self._entry.entry_id}_spool_{spool_data['id']}_extra_{safe_field_key}"
         self._attr_has_entity_name = False
-        self._attr_name = f"{spool_name} Extra {field_key.replace('_', ' ').title()}"
-        self._attr_icon = "mdi:tag-outline"
+        self._attr_name = f"{spool_name} Extra {display_name}"
+
+        device_class, icon = _device_class_for(field_type, unit)
+        if device_class is not None:
+            self._attr_device_class = device_class
+        self._attr_icon = icon
+
+        if field_type in _NUMERIC_FIELD_TYPES:
+            self._attr_state_class = SensorStateClass.MEASUREMENT
+
+        if unit:
+            self._attr_native_unit_of_measurement = unit
+
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.config[CONF_URL], f"spool_{self._spool['id']}")}  # type: ignore[arg-type]
         )
@@ -91,6 +146,7 @@ class SpoolExtraField(CoordinatorEntity, SensorEntity):
         # Convert value to string if it's a complex type
         if isinstance(value, dict | list):
             import json
+
             return json.dumps(value)
 
         return value


### PR DESCRIPTION
Reworks #837 to keep the integration as a clean Spoolman ↔ HA bridge.

## What

Fetches `/api/v1/field/spool` from Spoolman once per coordinator update and uses the reported `field_type` and `unit` to set proper `device_class`, `state_class`, native unit and icon on the dynamic `SpoolExtraField` sensors.

| Spoolman metadata | HA result |
| --- | --- |
| `field_type: integer/float` | `SensorStateClass.MEASUREMENT` (long-term statistics, graphs work) |
| `field_type: datetime` | `SensorDeviceClass.TIMESTAMP` |
| `unit: %` | `SensorDeviceClass.HUMIDITY` |
| `unit: °C / °F / K` | `SensorDeviceClass.TEMPERATURE` |
| `unit: g / kg` | `SensorDeviceClass.WEIGHT` |
| `unit: mm / m` | `SensorDeviceClass.DISTANCE` |
| any `unit` | `native_unit_of_measurement` |

## Differences vs #837

- **No locale-fragile name matching.** The original PR matched on the literal display name `"Humidity"` / `"Temperature"`; mapping is now done on `unit` so it works for any language.
- **No breaking change to `spool["extra"]`.** The raw value stays at the leaf — existing templates and automations keep working. Metadata lives in `coordinator.data["extra_fields"]["spool"]`.
- **No Python <3.12 syntax bug** (nested same-quote f-string) and no duplicate `SensorStateClass` import.
- **Graceful degradation** when the Spoolman version doesn't expose `/field/spool` (or the call fails) — sensors fall back to the previous behavior.
- **One metadata fetch per coordinator update**, not one per spool with extras.

## Credit

Original idea + initial implementation by @lp55 in #837 — thank you. Reworking here to address the syntax / locale / breaking-change feedback.

Closes #837