### PR TITLE
fix: dynamically add new spools and expose empty Spoolman locations

### DIFF
--- a/custom_components/spoolman/classes/spoolman_api.py
+++ b/custom_components/spoolman/classes/spoolman_api.py
@@ -59,6 +59,21 @@ class SpoolmanAPI:
             _LOGGER.debug("SpoolmanAPI: backup response %s", response)
             return response
 
+    async def get_locations(self):
+        """Return the list of configured spool locations from Spoolman.
+
+        Uses ``GET /api/v1/location`` so that locations without any assigned
+        spool (e.g. empty AMS trays) are still selectable in HA.
+        """
+        _LOGGER.debug("SpoolmanAPI: get_locations")
+        url = f"{self.base_url}/location"
+        session = await self._get_session()
+        async with session.get(url) as response:
+            response.raise_for_status()
+            payload = await response.json()
+            _LOGGER.debug("SpoolmanAPI: get_locations response %s", payload)
+            return [str(loc) for loc in payload if loc]
+
     async def get_extra_fields(self, entity_type):
         """Return extra-field metadata for the given entity type (e.g. ``spool``).
 

--- a/custom_components/spoolman/coordinator.py
+++ b/custom_components/spoolman/coordinator.py
@@ -64,6 +64,13 @@ class SpoolManCoordinator(DataUpdateCoordinator):
                 # Older Spoolman versions or transient errors: degrade gracefully.
                 _LOGGER.debug("Could not fetch spool extra-field metadata: %s", exception)
                 spool_extra_fields = {}
+            try:
+                locations = await self.spoolman_api.get_locations()
+            except Exception as exception:
+                # /location endpoint isn't on every Spoolman version; fall back
+                # to deriving from spools at the consumer side.
+                _LOGGER.debug("Could not fetch locations: %s", exception)
+                locations = None
         except asyncio.CancelledError:
             # Task was cancelled (e.g., during shutdown), re-raise to let coordinator handle it
             _LOGGER.debug("Data update was cancelled")
@@ -104,10 +111,20 @@ class SpoolManCoordinator(DataUpdateCoordinator):
             _LOGGER.error(f"Error processing Klipper API data: {exception}")
             # Continue returning spools even if Klipper processing fails
 
+        # Fall back to deriving locations from spools when Spoolman doesn't
+        # expose /location, so older servers keep working.
+        if locations is None:
+            locations = sorted({
+                spool["location"]
+                for spool in spools
+                if spool.get("location")
+            })
+
         return {
             "spools": spools,
             "filaments": filaments,
             "extra_fields": {"spool": spool_extra_fields},
+            "locations": locations,
         }
 
     async def async_cleanup_extra_fields(self):

--- a/custom_components/spoolman/select.py
+++ b/custom_components/spoolman/select.py
@@ -16,6 +16,19 @@ _LOGGER = logging.getLogger(__name__)
 ICON = "mdi:map-marker"
 
 
+def _resolve_locations(coordinator_data, spools):
+    """Pick the canonical location list, preferring Spoolman's /location feed.
+
+    Falls back to the set of locations actually used by spools so older
+    Spoolman servers (without /api/v1/location) still work.
+    """
+    locations = coordinator_data.get("locations") if coordinator_data else None
+    if locations:
+        return sorted(set(locations))
+    derived = {spool["location"] for spool in spools if spool.get("location")}
+    return sorted(derived)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -44,25 +57,47 @@ async def async_setup_entry(
     spool_data = coordinator.data.get("spools", [])
     _LOGGER.info("Found %d spools to create select entities for", len(spool_data))
 
-    # Get unique locations from all spools
-    locations = set()
-    for spool in spool_data:
-        location = spool.get("location")
-        if location:
-            locations.add(location)
-
+    locations = _resolve_locations(coordinator.data, spool_data)
     _LOGGER.info("Found locations: %s", locations)
+
+    existing_spool_ids: set = set()
 
     # Create a select entity for each spool
     for spool in spool_data:
         select_entity = SpoolLocationSelect(
-            hass, coordinator, spool, list(locations), config_entry
+            hass, coordinator, spool, locations, config_entry
         )
         all_entities.append(select_entity)
+        existing_spool_ids.add(spool["id"])
         _LOGGER.debug("Created select entity for spool %s", spool['id'])
 
     _LOGGER.info("Adding %d select entities", len(all_entities))
     async_add_entities(all_entities)
+
+    @callback
+    def add_dynamic_selects():
+        """Add a location select for spools that appeared after setup (#327)."""
+        if not coordinator.data:
+            return
+        new_entities = []
+        current_locations = _resolve_locations(
+            coordinator.data, coordinator.data.get("spools", [])
+        )
+        for spool in coordinator.data.get("spools", []):
+            spool_id = spool.get("id")
+            if spool_id in existing_spool_ids:
+                continue
+            new_entities.append(
+                SpoolLocationSelect(
+                    hass, coordinator, spool, current_locations, config_entry
+                )
+            )
+            existing_spool_ids.add(spool_id)
+            _LOGGER.info("Dynamically adding location select for spool %s", spool_id)
+        if new_entities:
+            async_add_entities(new_entities)
+
+    coordinator.async_add_listener(add_dynamic_selects)
 
 
 class SpoolLocationSelect(CoordinatorEntity, SelectEntity):
@@ -163,13 +198,12 @@ class SpoolLocationSelect(CoordinatorEntity, SelectEntity):
         self._attr_available = True
         self._spool = spool_data
 
-        # Update available locations from all spools
-        locations = set()
-        for spool in self.coordinator.data.get("spools", []):
-            location = spool.get("location")
-            if location:
-                locations.add(location)
-
-        self._locations = sorted(locations) if locations else ["Unknown"]
+        # Refresh available locations from coordinator (Spoolman /location
+        # feed) with fallback to spool-derived set.
+        locations = _resolve_locations(
+            self.coordinator.data,
+            self.coordinator.data.get("spools", []),
+        )
+        self._locations = locations if locations else ["Unknown"]
 
         self.async_write_ha_state()

--- a/custom_components/spoolman/sensor.py
+++ b/custom_components/spoolman/sensor.py
@@ -57,26 +57,126 @@ async def async_setup_entry(  # noqa: C901
     # Use the coordinator from hass.data that was created in __init__.py
     coordinator = hass.data[DOMAIN]["coordinator"]
 
-    # Track existing extra field entities to detect new ones
-    existing_extra_fields = {}  # key: (spool_id, field_key), value: entity
+    # Track which spools / extra fields we've already materialised so we can
+    # add brand-new spools and extras when the coordinator notices them
+    # (#327: previously only extra fields were added dynamically; new spools
+    # required a full integration reload).
+    existing_spool_ids: set = set()
+    existing_extra_fields: dict = {}  # key: (spool_id, field_key), value: entity
+
+    image_dir = hass.config.path(PUBLIC_IMAGE_PATH)
+
+    async def _build_entities_for_spool(spool, idx):
+        """Build the full sensor stack for a single spool."""
+        entities: list = []
+        image_url = await hass.async_add_executor_job(
+            _generate_entity_picture, spool, image_dir
+        )
+        entities.append(Spool(hass, coordinator, spool, idx, config_entry, image_url))
+        entities.append(SpoolFlowRate(hass, coordinator, spool, config_entry))
+        entities.append(SpoolEstimatedRunOut(hass, coordinator, spool, config_entry))
+        entities.append(SpoolUsedWeight(hass, coordinator, spool, config_entry))
+        entities.append(SpoolRemainingLength(hass, coordinator, spool, config_entry))
+        entities.append(SpoolUsedLength(hass, coordinator, spool, config_entry))
+        entities.append(SpoolLocation(hass, coordinator, spool, config_entry))
+        entities.append(SpoolUsedPercentage(hass, coordinator, spool, config_entry))
+
+        if spool.get("registered"):
+            entities.append(SpoolRegistered(hass, coordinator, spool, config_entry))
+        if spool.get("first_used"):
+            entities.append(SpoolFirstUsed(hass, coordinator, spool, config_entry))
+        if spool.get("last_used"):
+            entities.append(SpoolLastUsed(hass, coordinator, spool, config_entry))
+        if spool.get("price") is not None:
+            entities.append(SpoolPrice(hass, coordinator, spool, config_entry))
+        if spool.get("spool_weight") is not None:
+            entities.append(SpoolWeight(hass, coordinator, spool, config_entry))
+        if spool.get("lot_nr"):
+            entities.append(SpoolLotNumber(hass, coordinator, spool, config_entry))
+        if spool.get("comment"):
+            entities.append(SpoolComment(hass, coordinator, spool, config_entry))
+
+        filament = spool.get("filament", {})
+        if filament.get("density") is not None:
+            entities.append(FilamentDensity(hass, coordinator, spool, config_entry))
+        if filament.get("diameter") is not None:
+            entities.append(FilamentDiameter(hass, coordinator, spool, config_entry))
+        if filament.get("settings_extruder_temp") is not None:
+            entities.append(FilamentExtruderTemp(hass, coordinator, spool, config_entry))
+        if filament.get("settings_bed_temp") is not None:
+            entities.append(FilamentBedTemp(hass, coordinator, spool, config_entry))
+        if filament.get("article_number"):
+            entities.append(FilamentArticleNumber(hass, coordinator, spool, config_entry))
+
+        entities.append(SpoolId(hass, coordinator, spool, config_entry))
+
+        if filament.get("name"):
+            entities.append(FilamentName(hass, coordinator, spool, config_entry))
+        if filament.get("material"):
+            entities.append(FilamentMaterial(hass, coordinator, spool, config_entry))
+        if filament.get("color_hex"):
+            filament_image_url = await hass.async_add_executor_job(
+                _generate_filament_entity_picture, filament, image_dir
+            )
+            entities.append(
+                FilamentColorHex(
+                    hass, coordinator, spool, config_entry, filament_image_url
+                )
+            )
+        if filament.get("vendor", {}).get("name"):
+            entities.append(VendorName(hass, coordinator, spool, config_entry))
+        if filament.get("weight") is not None:
+            entities.append(FilamentWeight(hass, coordinator, spool, config_entry))
+
+        for field_key in spool.get("extra", {}):
+            extra_sensor = SpoolExtraField(
+                hass, coordinator, spool, config_entry, field_key
+            )
+            entities.append(extra_sensor)
+            existing_extra_fields[(spool["id"], field_key)] = extra_sensor
+
+        existing_spool_ids.add(spool["id"])
+        return entities
+
+    async def _async_add_new_spools(new_spools):
+        """Build & register sensors for spools the coordinator just discovered."""
+        new_entities: list = []
+        # Use a stable index continuation for the picture filename.
+        base_idx = len(existing_spool_ids)
+        for offset, spool in enumerate(new_spools):
+            _LOGGER.info(
+                "Dynamically adding sensors for new spool %s", spool.get("id")
+            )
+            new_entities.extend(
+                await _build_entities_for_spool(spool, base_idx + offset)
+            )
+        if new_entities:
+            async_add_entities(new_entities)
 
     @callback
-    def add_extra_field_entities():
-        """Add new extra field entities when they appear in coordinator data."""
+    def add_dynamic_entities():
+        """Add new spools and new extra-field sensors as they appear."""
         if not coordinator.data:
             return
 
-        new_entities = []
         spools = coordinator.data.get("spools", [])
 
+        # New spools (#327): full sensor stack, async because of image gen.
+        new_spools = [
+            s for s in spools if s.get("id") not in existing_spool_ids
+        ]
+        if new_spools:
+            hass.async_create_task(_async_add_new_spools(new_spools))
+
+        # New extra fields on already-known spools.
+        new_entities = []
         for spool in spools:
             spool_id = spool.get("id")
-            extra_data = spool.get("extra", {})
-
-            for field_key in extra_data:
+            if spool_id not in existing_spool_ids:
+                # Will be handled by _async_add_new_spools above.
+                continue
+            for field_key in spool.get("extra", {}):
                 entity_key = (spool_id, field_key)
-
-                # Only create if it doesn't exist yet
                 if entity_key not in existing_extra_fields:
                     extra_field_sensor = SpoolExtraField(
                         hass, coordinator, spool, config_entry, field_key
@@ -84,7 +184,9 @@ async def async_setup_entry(  # noqa: C901
                     new_entities.append(extra_field_sensor)
                     existing_extra_fields[entity_key] = extra_field_sensor
                     _LOGGER.info(
-                        f"Dynamically adding new extra field sensor for spool {spool_id}: {field_key}"
+                        "Dynamically adding new extra field sensor for spool %s: %s",
+                        spool_id,
+                        field_key,
                     )
 
         if new_entities:
@@ -92,7 +194,6 @@ async def async_setup_entry(  # noqa: C901
 
     if coordinator.data:
         all_entities = []
-        image_dir = hass.config.path(PUBLIC_IMAGE_PATH)
 
         # Create spool entities
         spool_data = coordinator.data.get("spools", [])
@@ -104,6 +205,7 @@ async def async_setup_entry(  # noqa: C901
                 hass, coordinator, spool, idx, config_entry, image_url
             )
             all_entities.append(spool_device)
+            existing_spool_ids.add(spool["id"])
 
             # Create flow rate sensor for this spool
             flow_rate_sensor = SpoolFlowRate(
@@ -312,8 +414,9 @@ async def async_setup_entry(  # noqa: C901
 
         async_add_entities(all_entities)
 
-    # Register listener for coordinator updates to add new extra fields
-    coordinator.async_add_listener(add_extra_field_entities)
+    # Register listener for coordinator updates so new spools (#327) and new
+    # extra fields are added without requiring an integration reload.
+    coordinator.async_add_listener(add_dynamic_entities)
 
 
 def _generate_entity_picture(spool_data, image_dir):


### PR DESCRIPTION
Closes #327, closes #835.

## #327 — new spools require integration reload

`sensor.py` and `select.py` only built entities for spools known at `async_setup_entry` time. Brand-new spools created in Spoolman therefore stayed invisible until the integration was reloaded.

Both platforms now register a coordinator listener that:
- detects spool ids it hasn't seen before,
- builds the full sensor stack (Spool + flow rate + run-out + length + location + percentages + filament metadata + ID + extra fields) and the location select on the fly,
- continues to add new extra-field sensors on already-known spools.

The existing image-generation path (`async_add_executor_job`) is reused via `hass.async_create_task` so the synchronous coordinator listener can kick off the async build without blocking.

## #835 — empty locations missing from dropdown

The location dropdown was derived from `spool.location` of all known spools, so a location configured in Spoolman but not yet assigned to a spool (e.g. empty AMS trays) was never selectable.

The coordinator now fetches `GET /api/v1/location` once per refresh and exposes the canonical list via `coordinator.data['locations']`. `SpoolLocationSelect` consumes that list both at setup and on every coordinator update.

## Compatibility

Older Spoolman versions without `/api/v1/location` are detected (request raises) and the integration falls back to the previous spool-derived location set. No breaking changes for existing users.