### PR TITLE
ci: skip PR title and target-branch checks on the dev->main release PR

### DIFF
--- a/.github/workflows/check-conventional-commits.yml
+++ b/.github/workflows/check-conventional-commits.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   check-commits:
     runs-on: ubuntu-latest
+    # Skip the auto-generated dev -> main release PR (its title is intentionally
+    # a non-conventional-commit summary).
+    if: |
+      !(github.event.pull_request.head.ref == 'dev' &&
+        github.event.pull_request.base.ref == 'main')
     permissions:
       pull-requests: write
       statuses: write

--- a/.github/workflows/check-pr-target-branch.yml
+++ b/.github/workflows/check-pr-target-branch.yml
@@ -9,11 +9,15 @@ on:
 jobs:
   check-target-branch:
     runs-on: ubuntu-latest
-    # Skip for bot accounts (renovate, dependabot, etc.)
+    # Skip for bot accounts (renovate, dependabot, etc.) and for the
+    # auto-generated dev -> main release PR (opened by github-actions[bot],
+    # which the maintainer-permission lookup rejects).
     if: |
       github.actor != 'renovate[bot]' &&
       github.actor != 'dependabot[bot]' &&
-      !contains(github.actor, '[bot]')
+      !contains(github.actor, '[bot]') &&
+      !(github.event.pull_request.head.ref == 'dev' &&
+        github.event.pull_request.base.ref == 'main')
     permissions:
       pull-requests: write
       issues: write


### PR DESCRIPTION
## Why

Every push to `dev` triggers the Auto-PR workflow which keeps PR #305 (`🚀 Release: Merge dev into main`) up to date. That PR then runs the standard PR checks and fails two of them on every update:

| Check | Why it fails |
| --- | --- |
| Conventional Commit Checker | The release-PR title is a human summary, not a conventional commit. |
| Check PR Target Branch | The PR is owned by `github-actions[bot]` whose `getCollaboratorPermissionLevel` returns `none`, so the maintainer-bypass doesn't kick in. |

Result: 2 red checks per dev push, no signal value. Looks like a regression on every contributor PR even though nothing is actually broken.

## Fix

Both jobs now early-skip when `head_ref == 'dev' && base_ref == 'main'` — i.e. exclusively the auto-generated release PR. All other PRs (including community PRs targeting `main` by mistake, which is what the target-branch check is meant to catch) keep being validated.

No changes to the actual checker logic.