### PR TITLE
ci: skip PR title and target-branch checks on the dev->main release PR

### DIFF
--- a/.github/workflows/check-conventional-commits.yml
+++ b/.github/workflows/check-conventional-commits.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   check-commits:
     runs-on: ubuntu-latest
+    # Skip the auto-generated dev -> main release PR (its title is intentionally
+    # a non-conventional-commit summary).
+    if: |
+      !(github.event.pull_request.head.ref == 'dev' &&
+        github.event.pull_request.base.ref == 'main')
     permissions:
       pull-requests: write
       statuses: write

--- a/.github/workflows/check-pr-target-branch.yml
+++ b/.github/workflows/check-pr-target-branch.yml
@@ -9,11 +9,15 @@ on:
 jobs:
   check-target-branch:
     runs-on: ubuntu-latest
-    # Skip for bot accounts (renovate, dependabot, etc.)
+    # Skip for bot accounts (renovate, dependabot, etc.) and for the
+    # auto-generated dev -> main release PR (opened by github-actions[bot],
+    # which the maintainer-permission lookup rejects).
     if: |
       github.actor != 'renovate[bot]' &&
       github.actor != 'dependabot[bot]' &&
-      !contains(github.actor, '[bot]')
+      !contains(github.actor, '[bot]') &&
+      !(github.event.pull_request.head.ref == 'dev' &&
+        github.event.pull_request.base.ref == 'main')
     permissions:
       pull-requests: write
       issues: write


### PR DESCRIPTION
Cherry-picks the CI fix from #840 directly to `main` so it takes effect for the release PR (#305).

`pull_request_target` evaluates the workflow definition from the **base** branch (`main`), so the fix on `dev` alone doesn't help the currently-failing 'Check PR Target Branch' run — that one keeps using the `main` copy of the workflow until this lands.

Identical change to #840, no logic differences.