### PR TITLE
ci: skip Conventional Commit check on bot-authored PRs

### DIFF
--- a/.github/workflows/check-conventional-commits.yml
+++ b/.github/workflows/check-conventional-commits.yml
@@ -7,11 +7,17 @@ on:
 jobs:
   check-commits:
     runs-on: ubuntu-latest
-    # Skip the auto-generated dev -> main release PR (its title is intentionally
-    # a non-conventional-commit summary).
+    # Skip:
+    #  - the auto-generated dev -> main release PR (its title is intentionally
+    #    a non-conventional-commit summary), and
+    #  - PRs opened by automation accounts (renovate, dependabot,
+    #    github-actions[bot], ...). They follow their own title schemes and we
+    #    don't want to spam them with format-required comments.
     if: |
       !(github.event.pull_request.head.ref == 'dev' &&
-        github.event.pull_request.base.ref == 'main')
+        github.event.pull_request.base.ref == 'main') &&
+      github.event.pull_request.user.type != 'Bot' &&
+      !contains(github.event.pull_request.user.login, '[bot]')
     permissions:
       pull-requests: write
       statuses: write


### PR DESCRIPTION
Follow-up to #840 / #841.

Renovate, dependabot, and `github-actions[bot]` author PRs that the conventional-commit checker can't help — they don't react to the bot comment, and most of their titles already follow the convention anyway. The format-required spam on those PRs is noise.

Skip the job when:
- `pr.user.type == 'Bot'`, or
- `pr.user.login` contains `[bot]`.

Existing release-PR skip (head=dev, base=main) is preserved.