### PR TITLE
fix: support alpha-enabled multi-color filament hex values

### DIFF
--- a/custom_components/spoolman/sensor.py
+++ b/custom_components/spoolman/sensor.py
@@ -482,16 +482,17 @@ def _generate_filament_entity_picture(filament_data, image_dir):
     multi_color_hexes = filament_data.get("multi_color_hexes", "").split(",")
     color_hex = filament_data.get("color_hex", DEFAULT_SPOOL_COLOR_HEX)
     multi_color_direction = filament_data.get("multi_color_direction", "coaxial")
+    id = filament_data.get("id", "unknown")
 
     # Determine colors: prioritize multi_color_hexes if available
     if multi_color_hexes and any(c.strip() for c in multi_color_hexes):
-        colors = [c.strip() for c in multi_color_hexes if len(c.strip()) == 6]
+        colors = [c.strip() for c in multi_color_hexes]
     elif color_hex:
         colors = [color_hex]
     else:
         _LOGGER.warning(
             "SpoolManCoordinator: Filament with ID '%s' has no valid color information.",
-            filament_data.get("id", "unknown"),
+            id
         )
         return None
 


### PR DESCRIPTION
## 🎯 Description

Fixes a bug in filament entity picture generation when Spoolman returns multi-color hex values with an alpha channel, for example `FF6A13FF`.

Previously, multi-color values were only handled correctly when each hex color was 6 characters long. As a result, some valid multi-color filaments could fail to render their entity picture correctly when 8-character hex values were present.

This change keeps the multi-color values intact so Home Assistant can generate the filament picture without rejecting alpha-enabled colors.

## 🔗 Related Issue

No related issue.

This change is needed because some Spoolman setups return 8-character hex colors for multi-color filaments, which caused broken image generation in the integration.

## 🎨 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Configuration change
- [ ] 🎨 UI/UX improvement

## 🧪 Testing

- [x] I have tested this code locally
- [ ] I have added/updated unit tests that prove my fix/feature works
- [ ] All existing tests pass locally
- [x] I have tested this in Home Assistant

### Test Environment

- Home Assistant version: 2026.2.3
- Python version: 3.13.3
- Integration version: 1.24.0
- Spoolman version: 0.23.1

### Test Scenarios

1. Configure a filament with `multi_color_hexes` containing standard 6-character values.
2. Configure a filament with `multi_color_hexes` containing 8-character values with alpha, such as `FF6A13FF`.
3. Confirm that the filament entity picture is generated correctly in both cases and no error is raised.

## 📸 Screenshots/Videos

Not applicable.

## ✅ Checklist

- [x] 📖 My code follows the project's coding style
- [x] 🔍 I have performed a self-review of my code
- [ ] 💬 I have commented my code, particularly in hard-to-understand areas
- [ ] 📚 I have updated the documentation (README, CONTRIBUTING, etc.) if needed
- [x] ⚠️ My changes generate no new warnings or errors
- [ ] 🧪 I have added tests that prove my fix is effective or that my feature works
- [ ] ✅ New and existing unit tests pass locally with my changes
- [x] 🌿 I am merging into the `dev` branch (not `main`)
- [x] 📝 My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
- [ ] 🔄 I have updated the integration version in `manifest.json` if needed
- [ ] 🌍 I have updated translations if I changed user-facing strings

## 📋 Commit Message Format

Example commit message used for this change:
- `fix: support alpha-enabled multi-color filament hex values`

## 🚀 Migration Notes

Not applicable.

## 📝 Additional Notes

This is a focused bug fix and does not change the public configuration or entity model.

## 🙏 Acknowledgments

Thanks to the maintainers for reviewing.